### PR TITLE
update readme regarding yarn installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm i -g depercolator
 or
 
 ```text
-yarn add global depercolator
+yarn global add depercolator
 ```
 
 ## Usage


### PR DESCRIPTION
ensure global is before package name as per docs,
- https://yarnpkg.com/en/docs/cli/global

> global is a command which must immediately follow yarn.
Entering yarn add global package-name will add the packages
named global and package-name locally
instead of adding package-name globally.