### PR TITLE
[WIP] Add initial support for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const program = require('commander');
 const shell = require('shelljs');
 const resolveBin = require('resolve-bin');
 
+const nodePath = process.execPath;
 const decafPath = resolveBin.sync('decaffeinate');
 const prettierPath = resolveBin.sync('prettier');
 const jscodeshiftPath = resolveBin.sync('jscodeshift');
@@ -47,26 +48,45 @@ function passFlag(option) {
 }
 
 function decaffeinateCommand() {
-  const command = [decafPath];
+  const command = [nodePath, decafPath];
   const options = decaffeinateOptions.map(([option]) => passFlag(option));
 
   return command.concat(options).join(' ');
 }
 
 function prettierCommand(file) {
-  const command = [`${prettierPath} --write`];
+  const command = [nodePath, prettierPath, '--write'];
 
   const options = prettierOptions.map(([option]) => passFlag(option));
 
-  return command.concat(options).concat(file).join(' ');
+  return stringifyCommand(command.concat(options).concat(file));
 }
 
 function cjsxTransformCommand(file) {
-  return [cjsxTransformPath, file].join(' ');
+  const command = [nodePath, cjsxTransformPath, file];
+
+  return stringifyCommand(command);
 }
 
 function jsCodeShiftCommand(file) {
-  return [jscodeshiftPath, '-t', rceToJSXPath, file].join(' ');
+  const command = [nodePath, jscodeshiftPath, '-t', rceToJSXPath, file];
+
+  return stringifyCommand(command);
+}
+
+function stringifyCommand(parts) {
+  if (process.platform === 'win32') {
+    // On Windows, it's common for programs to be installed into "C:\Program Files (x86)\..." which
+    // causes issues when trying to run commands - as the space is interpreted as an argument delimiter.
+    parts = parts.map(part => {
+      // Only quote strings containing a space, and haven't already been quoted
+      if (part.indexOf(' ') !== -1 && !/^\".*\"$/.test(part)) {
+        return `"${str}"`;
+      }
+      return part;
+    });
+  }
+  return parts.join(' ');
 }
 
 function makeOutputPath(file) {


### PR DESCRIPTION
It seems the issue was more complex than expected.

The commands need to be passed to the Node.js executable on Windows, which basically means that it was necessary to prefix all the commands with "node.exe". Which is now working fine.

I am still working on the fix for the spaces in a Windows path. I've tried many different "solutions", however it seems the path always ends up unescaped at some point (my current hunch is that it gets unescaped in shelljs).

- Quoting individual space (`C:\Program" "Files" "(x86)\nodejs\node.exe foobar.js`)
- Quoting each part of the command (`"C:\Program Files (x86)\nodejs\node.exe" "foobar.js"`)
- Chomping on a carrot (`C:\Program^ Files^ (x86)\nodejs\node.exe foobar.js`)

All of the above are said to have worked for people on the internet - and as we all know; people on the internet do not lie or give false information.

The weird part is that if I run the commands being generated in-code in Powershell (manually), they work. Hence why I think shelljs is screwing with it somehow.

I will take another look tomorrow evening. Until then, suggestions/thoughts/ideas are welcome! 😛

Ooh, and one more thing. It seems that the `jscodeshift` library isn't working on Windows either. Even with no spaces in the path it fails. I'm not currently focused on it for now though. I really want to get the original issue (#6) fixed first.