### PR TITLE
Handle invalid files better, remove shell.js

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -11,13 +11,9 @@ function mapExtension(source) {
 }
 
 async function run(filename, flags = '') {
-  const source = path.resolve(`./fixtures/${filename}`);
+  const source = path.resolve(filename);
   const outputPath = mapExtension(source);
-  const { stderr } = await execAsync(`${COMMAND} ${flags} ${source}`);
-
-  if (stderr) {
-    throw stderr;
-  }
+  await execAsync(`${COMMAND} ${flags} ${source}`);
 
   const result = await fs.readFile(outputPath, 'utf8');
   fs.unlink(outputPath);
@@ -26,8 +22,15 @@ async function run(filename, flags = '') {
 
 describe('happy test', () => {
   it('converts the file', async () => {
-    const result = await run('testfile.cjsx');
+    const result = await run('./fixtures/testfile.cjsx');
     expect(result).toMatchSnapshot();
+  });
+});
+
+describe('invalid option', () => {
+  it('throws the error', async () => {
+    expect.assertions(1);
+    await expect(run('./fixtures/badfile.cjsx')).rejects.toBeDefined();
   });
 });
 

--- a/fixtures/badfile.cjsx
+++ b/fixtures/badfile.cjsx
@@ -1,0 +1,5 @@
+
+module.exports = React.createClass({
+  render: ->
+    <div className="hello">
+      <div>Hello</div>

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "commander": "^2.9.0",
     "decaffeinate": "^2.47.0",
     "lodash": "^4.17.4",
-    "prettier-eslint": "^6.2.2",
-    "resolve-bin": "^0.4.0",
-    "shelljs": "^0.7.6"
+    "prettier-eslint": "^6.2.2"
   },
   "devDependencies": {
     "async-child-process": "^1.1.1",
@@ -44,6 +42,7 @@
     "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "jest": "^20.0.1"
+    "jest": "^20.0.1",
+    "resolve-bin": "^0.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,10 +844,6 @@ caniuse-db@^1.0.30000639:
   version "1.0.30000670"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000670.tgz#90d33b79e3090e25829c311113c56d6b1788bf43"
 
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -1695,15 +1691,6 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
-har-validator@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
-  dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    is-my-json-valid "^2.12.4"
-    pinkie-promise "^2.0.0"
-
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
@@ -1898,7 +1885,7 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
+is-my-json-valid@^2.10.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
   dependencies:
@@ -2837,10 +2824,6 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@~6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
-
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
@@ -2966,32 +2949,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
-
-request@^2.81.0:
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -3126,7 +3084,7 @@ shebang-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-2.0.0.tgz#f500bf6851b61356236167de2cc319b0fd7f0681"
 
-shelljs@^0.7.5, shelljs@^0.7.6:
+shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
   dependencies:
@@ -3363,10 +3321,6 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
-
-tunnel-agent@~0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
Improves the output when attempting to convert and cjsx file with syntax errors. 
Also removes shelljs dependency. This may fix #6 