### PR TITLE
Issue-20 Fix passing int for options

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -51,3 +51,10 @@ describe('prettier options', () => {
     expect(flags).toMatchSnapshot();
   });
 });
+
+describe('flags with <int>', () => {
+  it('cleans the int', async () => {
+    const result = await run('./fixtures/testfile.cjsx', '--tab-width 4');
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,12 @@ const prettierOptions = [
 function getOptions(array) {
   const options = {};
   array.forEach(([flag]) => {
-    const key = camelCase(flag);
-    options[key] = program[key];
+    const key = camelCase(flag.replace(' <int>', ''));
+    let value = program[key];
+    if(typeof value === 'string') {
+      value = parseInt(value)
+    }
+    options[key] = value;
   });
 
   return options;

--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,8 @@ function getOptions(array) {
   array.forEach(([flag]) => {
     const key = camelCase(flag.replace(' <int>', ''));
     let value = program[key];
-    if(typeof value === 'string') {
-      value = parseInt(value)
+    if (/<int>/.test(flag) && typeof value === 'string') {
+      value = parseInt(value, 10);
     }
     options[key] = value;
   });


### PR DESCRIPTION
## What
- When we generate the `key` in `getOptions`, strip away ` <int>` before camel casing. 
- Check if the value for the key is a string, if it is then use `parseInt`

Note that [commander](https://www.npmjs.com/package/commander) seems to have an option where you can pass in `parseInt` in the option list if the option requires an int, but I couldn't get that working so I did it manually. 

## Why
Using an option that required an int wasn't working. The first issue was that the key generation was wrong so the value was always undefined. The second issue was that the option value was passed as a string but `prettier` expects an integer.

## Testing
- run the `build` command to get `dist/index.js`
- do `npm bin -g` to get the path of your global bin
- open the directory to the global bin in your text editor
- replace `depercolator` file with your newly built `dist/index.js` file
- Run `depercolate file.cjsx --tab-width 4` and it should work

## References
Issue #20 
[commander](https://www.npmjs.com/package/commander)