### PR TITLE
Correctly pass decaffinate --*-js-modules options

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -25,6 +25,52 @@ Array [
 ]
 `;
 
+exports[`flag --loose-js-modules does not camelcase js 1`] = `
+"/*
+ * decaffeinate suggestions:
+ * DS102: Remove unnecessary code created because of implicit returns
+ * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
+ */
+import React from 'react';
+
+const testConstant = 'foo';
+
+const klass = React.createClass({
+  render() {
+    return (
+      <div className=\\"hello\\">
+        <div>Hello</div>
+      </div>
+    );
+  },
+});
+
+export { klass as named };
+"
+`;
+
+exports[`flag --use-js-modules does not camelcase js 1`] = `
+"/*
+ * decaffeinate suggestions:
+ * DS102: Remove unnecessary code created because of implicit returns
+ * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
+ */
+import React from 'react';
+
+const testConstant = 'foo';
+
+export default React.createClass({
+  render() {
+    return (
+      <div className=\\"hello\\">
+        <div>Hello</div>
+      </div>
+    );
+  },
+});
+"
+`;
+
 exports[`flags with <int> cleans the int 1`] = `
 "/*
  * decaffeinate suggestions:

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -58,3 +58,17 @@ describe('flags with <int>', () => {
     expect(result).toMatchSnapshot();
   });
 });
+
+describe('flag --use-js-modules', () => {
+  it('does not camelcase js', async () => {
+    const result = await run('./fixtures/testfile.cjsx', '--use-js-modules');
+    expect(result).toMatchSnapshot();
+  });
+});
+
+describe('flag --loose-js-modules', () => {
+  it('does not camelcase js', async () => {
+    const result = await run('./fixtures/named_export.cjsx', '--loose-js-modules --use-js-modules');
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/fixtures/named_export.cjsx
+++ b/fixtures/named_export.cjsx
@@ -1,0 +1,13 @@
+React = require('react')
+
+testConstant = 'foo'
+
+klass = React.createClass({
+  render: ->
+    <div className="hello">
+      <div>Hello</div>
+    </div>
+})
+
+module.exports.named = klass
+

--- a/src/index.js
+++ b/src/index.js
@@ -62,10 +62,17 @@ function getOptions(array) {
   array.forEach(([flag]) => {
     const key = camelCase(flag.replace(' <int>', ''));
     let value = program[key];
+
     if (/<int>/.test(flag) && typeof value === 'string') {
       value = parseInt(value, 10);
     }
-    options[key] = value;
+    // decaffinate does not camelCase Js in --use-js-modules or --loose-js-modules
+    if (key === 'useJsModules')
+      options['useJSModules'] = value;
+    else if (key === 'looseJsModules')
+      options['looseJSModules'] = value;
+    else
+      options[key] = value
   });
 
   return options;


### PR DESCRIPTION
Do not use camelCase for js when passing --use-js-modules or --loose-js-modules options to decaffinate